### PR TITLE
Make IMDSv2 required by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,6 @@ variable "ec2_instance_type" {
   description = "Type of instance ec2"
 }
 
-
 variable "iam_profile" {
   description = "The IAM profile to attach to the ec2 instance."
   default     = null
@@ -65,7 +64,6 @@ variable "ssh_source_address" {
   description = "The source IP address for SSH connections, in CIDR notation."
 }
 
-
 variable "client_port" {
   description = "The port, within the indy range of 9700 to 9799, on which the client interface will listen."
   default     = "9702"
@@ -78,15 +76,22 @@ variable "node_port" {
 
 variable "vpc_node_cidr_block" {
   description = "VPC IP CIDR"
-
 }
 
 variable "ssh_key_name" {
   description = "Name of the EC2 ssh public key to use to ssh in"
-
 }
 
 variable "zone" {
   description = "Availability zone where to deploy the VM"
+}
 
+variable "http_tokens" {
+  description = "Whether or not the instance metadata service requires session tokens (IMDSv2). Valid values include 'optional' or 'required'."
+  default     = "required"
+}
+
+variable "http_endpoint" {
+  description = "Whether the metadata service is available. Valid values include enabled or disabled."
+  default     = "enabled"
 }

--- a/vm.tf
+++ b/vm.tf
@@ -75,6 +75,11 @@ resource "aws_instance" "indy_node" {
     device_index         = 0
   }
 
+  metadata_options {
+    http_tokens = var.http_tokens
+    http_endpoint = var.http_endpoint
+  }
+
   depends_on = [
     aws_internet_gateway.node_gateway
   ]


### PR DESCRIPTION
Updates the node configuration to enable IMDSv2 on instances by default.