### PR TITLE
Ansible json output

### DIFF
--- a/networking.tf
+++ b/networking.tf
@@ -2,7 +2,7 @@
 resource "aws_eip" "public_client_ip" {
   count = var.use_elastic_ips ? 1 : 0
 
-  vpc                       = true
+  domain                    = "vpc"
   network_interface         = aws_network_interface.client_nic[count.index].id
   associate_with_private_ip = aws_network_interface.client_nic[count.index].private_ip
 
@@ -19,7 +19,7 @@ resource "aws_eip" "public_client_ip" {
 resource "aws_eip" "public_node_ip" {
   count = var.use_elastic_ips ? 1 : 0
 
-  vpc                       = true
+  domain                    = "vpc"
   network_interface         = aws_network_interface.node_nic.id
   associate_with_private_ip = aws_network_interface.node_nic.private_ip
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "node_info" {
     # Remove special characters and crop to into a 32 character seed.
     substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32),
     # The node's public Client IP.   Used later on for automatic genesis file generation
-    aws_eip.public_client_ip,
+    aws_eip.public_client_ip.public_ip,
     # The node's public Node IP.  Used later on for automatic genesis file generation.  
     # Should be the same as the first output, but we are putting this here anyay for clarity.
-    aws_eip.public_node_ip
+    aws_eip.public_node_ip.public_ip
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,11 @@ output "node_info" {
     aws_ebs_volume.data_volume.id,
     # node_seed
     # Remove special characters and crop to into a 32 character seed.
-    substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32)
+    substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32),
+    # The node's public Client IP.   Used later on for automatic genesis file generation
+    aws_eip.public_client_ip,
+    # The node's public Node IP.  Used later on for automatic genesis file generation.  
+    # Should be the same as the first output, but we are putting this here anyay for clarity.
+    aws_eip.public_node_ip
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "node_info" {
     # Remove special characters and crop to into a 32 character seed.
     substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32),
     # The node's public Client IP.   Used later on for automatic genesis file generation
-    aws_eip.public_client_ip.public_ip[0],
+    aws_eip.public_client_ip[*].public_ip,
     # The node's public Node IP.  Used later on for automatic genesis file generation.  
     # Should be the same as the first output, but we are putting this here anyay for clarity.
-    aws_eip.public_node_ip.public_ip[0]
+    aws_eip.public_node_ip[*].public_ip
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "node_info" {
     # Remove special characters and crop to into a 32 character seed.
     substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32),
     # The node's public Client IP.   Used later on for automatic genesis file generation
-    aws_eip.public_client_ip.public_ip,
+    aws_eip.public_client_ip.public_ip[0],
     # The node's public Node IP.  Used later on for automatic genesis file generation.  
     # Should be the same as the first output, but we are putting this here anyay for clarity.
-    aws_eip.public_node_ip.public_ip
+    aws_eip.public_node_ip.public_ip[0]
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "node_info" {
     # Remove special characters and crop to into a 32 character seed.
     substr(replace(replace(random_id.node_seed.b64_url, "_", ""), "-", ""), 0, 32),
     # The node's public Client IP.   Used later on for automatic genesis file generation
-    aws_eip.public_client_ip[*].public_ip,
+    aws_eip.public_client_ip[0].public_ip,
     # The node's public Node IP.  Used later on for automatic genesis file generation.  
     # Should be the same as the first output, but we are putting this here anyay for clarity.
-    aws_eip.public_node_ip[*].public_ip
+    aws_eip.public_node_ip[0].public_ip
   ]
 }


### PR DESCRIPTION
The changes to the output is to allow for ansible, in a subsequent step,  to be able to parse the correct public IP, and not the internal IP.  

A small change also, potentially breaking change for those using an older version of the aws provider, that change vpc = true to domain = vpc.  That change is required because of a deprecated usage in the latest aws provider